### PR TITLE
Update to latest API methods, and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ and the token is just the token itself.
 
 ```
 docker run --rm \
-  -e GOOGLE_CHAT_WEBHOOK=https://dynamite.sandbox.googleapis.com/v1/rooms/... \
+  -e GOOGLE_CHAT_WEBHOOK=https://chat.googleapis.com/v1/spaces/... \
   -e GOOGLE_CHAT_KEY=somekey
   -e GOOGLE_CHAT_TOKEN=sometoken
   -e DRONE_REPO_OWNER=octocat \

--- a/google-chat/client.go
+++ b/google-chat/client.go
@@ -19,7 +19,12 @@ type client struct {
 }
 
 func NewClient(url string, key string, token string, conversationKey string) Client {
-	fullURL = url + "/messages?key=" + key + "&token=" + token
+	fullURL := ""
+	if conversationKey == "" {
+		fullURL = url + "/messages?key=" + key + "&token=" + token
+	} else {
+		fullURL = url + "/messages?key=" + key + "&token=" + token + "&threadKey=" + conversationKey
+	}
 	return &client{fullURL}
 }
 

--- a/google-chat/client.go
+++ b/google-chat/client.go
@@ -19,12 +19,7 @@ type client struct {
 }
 
 func NewClient(url string, key string, token string, conversationKey string) Client {
-	fullURL := ""
-	if conversationKey == "" {
-		fullURL = url + "/webhooks?key=" + key + "&token=" + token
-	} else {
-		fullURL = url + "/webhooks?key=" + key + "&token=" + token + "&conversation_key=" + conversationKey
-	}
+	fullURL = url + "/messages?key=" + key + "&token=" + token
 	return &client{fullURL}
 }
 


### PR DESCRIPTION
Fixes this error:

```
{
  "error": {
    "code": 400,
    "message": "dynamite.sandbox.googleapis.com is deprecated. Please use chat.googleapis.com.
 Refer to our documentation at
 https://developers.google.com/hangouts/chat/reference/rest/v1/spaces.messages/create.",
    "status": "INVALID_ARGUMENT"
  }
}
```